### PR TITLE
DE-149900: Add support for slow request logging with configurable threshold

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -608,9 +608,11 @@ class Client
             return $this->request($path, $method, $data, $query);
         }
 
-        if ($this->shouldLog()) {
+        $shouldLogSlowRequests = $this->shouldLogSlowRequests();
+
+        if ($this->shouldLog() || $shouldLogSlowRequests) {
             $elapsedTimeMs = (int)(round($response->getQueryTime() * 1000));
-            $isSlowRequest = $this->shouldLogSlowRequests() && $elapsedTimeMs > $this->slowRequestThresholdMs;
+            $isSlowRequest = $shouldLogSlowRequests && $elapsedTimeMs > $this->slowRequestThresholdMs;
 
             $context = [
                 'tags' => $tags,

--- a/src/Client.php
+++ b/src/Client.php
@@ -145,6 +145,13 @@ class Client
         return $this->loggingMode & self::LOG_SLOW_REQUESTS;
     }
 
+    private function isSlowRequest(Response $response): bool
+    {
+        $elapsedTimeMs = (int)(round($response->getQueryTime() * 1000));
+
+        return $elapsedTimeMs > $this->slowRequestThresholdMs;
+    }
+
     private function logSlowRequest(
         string $method,
         string $path,
@@ -666,22 +673,15 @@ class Client
             return $this->request($path, $method, $data, $query);
         }
 
-        $shouldLogSlowRequests = $this->shouldLogSlowRequests();
-
-        if (!$this->shouldLog() && !$shouldLogSlowRequests) {
-            return $response;
-        }
-
-        $elapsedTimeMs = (int)(round($response->getQueryTime() * 1000));
-        $isSlowRequest = $shouldLogSlowRequests && $elapsedTimeMs > $this->slowRequestThresholdMs;
-
-        if ($isSlowRequest) {
+        if ($this->shouldLogSlowRequests() && $this->isSlowRequest($response)) {
+            $elapsedTimeMs = (int)(round($response->getQueryTime() * 1000));
             $this->logSlowRequest($method, $path, $requestName, $elapsedTimeMs, $request, $response, $tags);
-
-            return $response;
         }
 
-        $this->logRequest($method, $path, $requestName, $elapsedTimeMs, $request, $response, $tags);
+        if ($this->shouldLog()) {
+            $elapsedTimeMs = (int)(round($response->getQueryTime() * 1000));
+            $this->logRequest($method, $path, $requestName, $elapsedTimeMs, $request, $response, $tags);
+        }
 
         return $response;
     }

--- a/src/Client.php
+++ b/src/Client.php
@@ -33,6 +33,8 @@ class Client
 
     public const LOG_RESPONSE_BODY = 0b0100;
 
+    public const LOG_SLOW_REQUESTS = 0b1000;
+
     /**
      * @var ClientConfiguration
      */
@@ -78,12 +80,15 @@ class Client
 
     private bool $isRetryFeatureEnabled;
 
+    private int $slowRequestThresholdMs = 500;
+
 
     /**
      * Creates a new Elastica client.
      *
      * @param array|string  $config   OPTIONAL Additional config or DSN of options
      * @param callable|null $callback OPTIONAL Callback function which can be used to be notified about errors (for example connection down)
+     * @param int           $slowRequestThresholdMs OPTIONAL Threshold in milliseconds for slow request logging (default: 500)
      *
      * @throws InvalidException
      */
@@ -92,7 +97,8 @@ class Client
         $callback = null,
         LoggerInterface $logger = null,
         RequestCounterInterface $requestCounter = null,
-        bool $isRetryFeatureEnabled = false
+        bool $isRetryFeatureEnabled = false,
+        int $slowRequestThresholdMs = 500
     ) {
         if (\is_string($config)) {
             $configuration = ClientConfiguration::fromDsn($config);
@@ -107,6 +113,7 @@ class Client
         $this->setLogger($logger ?? new NullLogger());
         $this->requestCounter = $requestCounter;
         $this->isRetryFeatureEnabled = $isRetryFeatureEnabled;
+        $this->slowRequestThresholdMs = $slowRequestThresholdMs;
 
         $this->_initConnections();
     }
@@ -129,6 +136,11 @@ class Client
     public function shouldLogResponseBody(): bool
     {
         return $this->loggingMode & self::LOG_RESPONSE_BODY;
+    }
+
+    public function shouldLogSlowRequests(): bool
+    {
+        return $this->loggingMode & self::LOG_SLOW_REQUESTS;
     }
 
     /**
@@ -598,13 +610,19 @@ class Client
 
         if ($this->shouldLog()) {
             $elapsedTimeMs = (int)(round($response->getQueryTime() * 1000));
+            $isSlowRequest = $this->shouldLogSlowRequests() && $elapsedTimeMs > $this->slowRequestThresholdMs;
+
             $context = [
                 'tags' => $tags,
                 'responseStatus' => $response->getStatus(),
                 'execution_time' => $elapsedTimeMs,
             ];
 
-            if ($this->shouldLogRequestBody()) {
+            // For slow requests, always log request body and add call stack
+            if ($isSlowRequest) {
+                $context['request'] = $request->toArray();
+                $context['exception'] = new \RuntimeException('slow query');
+            } elseif ($this->shouldLogRequestBody()) {
                 $context['request'] = $request->toArray();
             }
 
@@ -612,10 +630,17 @@ class Client
                 $context['response'] = $response->getData();
             }
 
-            $this->logger->debug(
-                sprintf('Elastica Request %s %s %s took %d ms', $method, $path, $requestName, $elapsedTimeMs),
-                $context
-            );
+            if ($isSlowRequest) {
+                $this->logger->warning(
+                    sprintf('Slow Elastica Request %s %s %s took %d ms', $method, $path, $requestName, $elapsedTimeMs),
+                    $context
+                );
+            } else {
+                $this->logger->debug(
+                    sprintf('Elastica Request %s %s %s took %d ms', $method, $path, $requestName, $elapsedTimeMs),
+                    $context
+                );
+            }
         }
 
         return $response;

--- a/src/Client.php
+++ b/src/Client.php
@@ -145,10 +145,8 @@ class Client
         return $this->loggingMode & self::LOG_SLOW_REQUESTS;
     }
 
-    private function isSlowRequest(Response $response): bool
+    private function isSlow(int $elapsedTimeMs): bool
     {
-        $elapsedTimeMs = (int)(round($response->getQueryTime() * 1000));
-
         return $elapsedTimeMs > $this->slowRequestThresholdMs;
     }
 
@@ -673,13 +671,13 @@ class Client
             return $this->request($path, $method, $data, $query);
         }
 
-        if ($this->shouldLogSlowRequests() && $this->isSlowRequest($response)) {
-            $elapsedTimeMs = (int)(round($response->getQueryTime() * 1000));
+        $elapsedTimeMs = (int)(round($response->getQueryTime() * 1000));
+
+        if ($this->shouldLogSlowRequests() && $this->isSlow($elapsedTimeMs)) {
             $this->logSlowRequest($method, $path, $requestName, $elapsedTimeMs, $request, $response, $tags);
         }
 
         if ($this->shouldLog()) {
-            $elapsedTimeMs = (int)(round($response->getQueryTime() * 1000));
             $this->logRequest($method, $path, $requestName, $elapsedTimeMs, $request, $response, $tags);
         }
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -675,6 +675,8 @@ class Client
 
         if ($this->shouldLogSlowRequests() && $this->isSlow($elapsedTimeMs)) {
             $this->logSlowRequest($method, $path, $requestName, $elapsedTimeMs, $request, $response, $tags);
+
+            return $response;
         }
 
         if ($this->shouldLog()) {

--- a/src/Client.php
+++ b/src/Client.php
@@ -35,6 +35,8 @@ class Client
 
     public const LOG_SLOW_REQUESTS = 0b1000;
 
+    public const DEFAULT_SLOW_REQUEST_THRESHOLD_IN_MS = 500;
+
     /**
      * @var ClientConfiguration
      */
@@ -80,7 +82,7 @@ class Client
 
     private bool $isRetryFeatureEnabled;
 
-    private int $slowRequestThresholdMs = 500;
+    private int $slowRequestThresholdMs;
 
 
     /**
@@ -98,7 +100,7 @@ class Client
         LoggerInterface $logger = null,
         RequestCounterInterface $requestCounter = null,
         bool $isRetryFeatureEnabled = false,
-        int $slowRequestThresholdMs = 500
+        int $slowRequestThresholdMs = self::DEFAULT_SLOW_REQUEST_THRESHOLD_IN_MS
     ) {
         if (\is_string($config)) {
             $configuration = ClientConfiguration::fromDsn($config);
@@ -141,6 +143,62 @@ class Client
     public function shouldLogSlowRequests(): bool
     {
         return $this->loggingMode & self::LOG_SLOW_REQUESTS;
+    }
+
+    private function logSlowRequest(
+        string $method,
+        string $path,
+        string $requestName,
+        int $elapsedTimeMs,
+        Request $request,
+        Response $response,
+        array $tags
+    ): void {
+        $context = [
+            'tags' => $tags,
+            'responseStatus' => $response->getStatus(),
+            'execution_time' => $elapsedTimeMs,
+            'request' => $request->toArray(),
+            'exception' => new \RuntimeException('slow query'),
+        ];
+
+        if ($this->shouldLogResponseBody()) {
+            $context['response'] = $response->getData();
+        }
+
+        $this->logger->warning(
+            sprintf('Slow Elastica Request %s %s %s took %d ms', $method, $path, $requestName, $elapsedTimeMs),
+            $context
+        );
+    }
+
+    private function logRequest(
+        string $method,
+        string $path,
+        string $requestName,
+        int $elapsedTimeMs,
+        Request $request,
+        Response $response,
+        array $tags
+    ): void {
+        $context = [
+            'tags' => $tags,
+            'responseStatus' => $response->getStatus(),
+            'execution_time' => $elapsedTimeMs,
+        ];
+
+        if ($this->shouldLogRequestBody()) {
+            $context['request'] = $request->toArray();
+        }
+
+        if ($this->shouldLogResponseBody()) {
+            $context['response'] = $response->getData();
+        }
+
+        $this->logger->debug(
+            sprintf('Elastica Request %s %s %s took %d ms', $method, $path, $requestName, $elapsedTimeMs),
+            $context
+        );
     }
 
     /**
@@ -610,40 +668,20 @@ class Client
 
         $shouldLogSlowRequests = $this->shouldLogSlowRequests();
 
-        if ($this->shouldLog() || $shouldLogSlowRequests) {
-            $elapsedTimeMs = (int)(round($response->getQueryTime() * 1000));
-            $isSlowRequest = $shouldLogSlowRequests && $elapsedTimeMs > $this->slowRequestThresholdMs;
-
-            $context = [
-                'tags' => $tags,
-                'responseStatus' => $response->getStatus(),
-                'execution_time' => $elapsedTimeMs,
-            ];
-
-            // For slow requests, always log request body and add call stack
-            if ($isSlowRequest) {
-                $context['request'] = $request->toArray();
-                $context['exception'] = new \RuntimeException('slow query');
-            } elseif ($this->shouldLogRequestBody()) {
-                $context['request'] = $request->toArray();
-            }
-
-            if ($this->shouldLogResponseBody()) {
-                $context['response'] = $response->getData();
-            }
-
-            if ($isSlowRequest) {
-                $this->logger->warning(
-                    sprintf('Slow Elastica Request %s %s %s took %d ms', $method, $path, $requestName, $elapsedTimeMs),
-                    $context
-                );
-            } else {
-                $this->logger->debug(
-                    sprintf('Elastica Request %s %s %s took %d ms', $method, $path, $requestName, $elapsedTimeMs),
-                    $context
-                );
-            }
+        if (!$this->shouldLog() && !$shouldLogSlowRequests) {
+            return $response;
         }
+
+        $elapsedTimeMs = (int)(round($response->getQueryTime() * 1000));
+        $isSlowRequest = $shouldLogSlowRequests && $elapsedTimeMs > $this->slowRequestThresholdMs;
+
+        if ($isSlowRequest) {
+            $this->logSlowRequest($method, $path, $requestName, $elapsedTimeMs, $request, $response, $tags);
+
+            return $response;
+        }
+
+        $this->logRequest($method, $path, $requestName, $elapsedTimeMs, $request, $response, $tags);
 
         return $response;
     }

--- a/src/ClientFactory.php
+++ b/src/ClientFactory.php
@@ -17,19 +17,23 @@ class ClientFactory
 
     private bool $isRetryFeatureEnabled;
 
+    private int $slowRequestThresholdMs;
+
 
     public function __construct(
         ServerConfiguration $serverConfiguration,
         RequestCounterInterface $requestCounter,
         LoggerInterface $lazyLogger,
         bool $isRequestLoggingEnabled,
-        bool $isRetryFeatureEnabled
+        bool $isRetryFeatureEnabled,
+        int $slowRequestThresholdMs = 500
     ) {
         $this->serverConfiguration = $serverConfiguration;
         $this->requestCounter = $requestCounter;
         $this->lazyLogger = $lazyLogger;
         $this->isRequestLoggingEnabled = $isRequestLoggingEnabled;
         $this->isRetryFeatureEnabled = $isRetryFeatureEnabled;
+        $this->slowRequestThresholdMs = $slowRequestThresholdMs;
     }
 
 
@@ -53,7 +57,8 @@ class ClientFactory
             null,
             null,
             $withRequestCounter ? $this->requestCounter : null,
-            $this->isRetryFeatureEnabled
+            $this->isRetryFeatureEnabled,
+            $this->slowRequestThresholdMs
         );
 
         $client->setLoggingMode($loggingMode);

--- a/src/ClientFactory.php
+++ b/src/ClientFactory.php
@@ -26,7 +26,7 @@ class ClientFactory
         LoggerInterface $lazyLogger,
         bool $isRequestLoggingEnabled,
         bool $isRetryFeatureEnabled,
-        int $slowRequestThresholdMs = 500
+        int $slowRequestThresholdMs = Client::DEFAULT_SLOW_REQUEST_THRESHOLD_IN_MS
     ) {
         $this->serverConfiguration = $serverConfiguration;
         $this->requestCounter = $requestCounter;


### PR DESCRIPTION
Description: Add support for OpenSearch slow request logging with configurable threshold
Possible impact: Elasticsearch/OpenSearch request logging, performance monitoring

---
## Summary
- Add `LOG_SLOW_REQUESTS` constant to enable slow request logging
- Implement configurable slow request threshold (default: 500ms)
- Log slow requests at warning level with call stack for debugging
- Always include request body in slow request logs
- All changes are fully backwards compatible

<img width="2741" height="874" alt="image" src="https://github.com/user-attachments/assets/24d1cbd7-209c-4288-a8a2-586901305c93" />

## Changes Made
- **Added**: `Client::LOG_SLOW_REQUESTS` constant (0b1000)
- **Added**: `$slowRequestThresholdMs` parameter to Client and ClientFactory constructors (default: 500ms)
- **Added**: `shouldLogSlowRequests()` helper method
- **Modified**: Request logging logic to detect slow requests and adjust log level/context
- **Modified**: ClientFactory to pass slow request threshold to Client

## Implementation Details
- When `LOG_SLOW_REQUESTS` is enabled and a request exceeds the threshold:
  - Log level changes from debug to warning
  - Message prefix changes to "Slow Elastica Request"
  - Request body is always logged (regardless of LOG_REQUEST_BODY flag)
  - Call stack is added via dummy `RuntimeException('slow query')` in log context
- The call stack will be automatically transformed by Monolog processors in platform-backend

## Backwards Compatibility
- All new parameters have default values
- Existing code will continue to work without any changes
- Slow logging is opt-in via the LOG_SLOW_REQUESTS flag

## Testing Plan
- [ ] Verify slow request detection works correctly
- [ ] Verify log level changes to warning for slow requests
- [ ] Verify request body is always logged for slow requests
- [ ] Verify call stack is included in log context
- [ ] Verify backwards compatibility with existing clients

🤖 Generated with [Claude Code](https://claude.com/claude-code)