### PR TITLE
DE-159650: Add ES v9 native client factory to Connection

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -2,10 +2,11 @@
 
 namespace Elastica;
 
+use Elastic\Elasticsearch\Client as ElasticsearchClient;
+use Elastic\Elasticsearch\ClientBuilder;
 use Elastica\Exception\InvalidException;
 use Elastica\Transport\AbstractTransport;
 use Psr\Log\LoggerInterface;
-use Psr\Log\NullLogger;
 
 /**
  * Elastica connection instance to an elasticasearch node.
@@ -14,6 +15,11 @@ use Psr\Log\NullLogger;
  */
 class Connection extends Param
 {
+    /**
+     * Cached elasticsearch-php v9 client instance.
+     */
+    private ?ElasticsearchClient $_client = null;
+
     /**
      * Default elastic search port.
      */
@@ -61,7 +67,6 @@ class Connection extends Param
         $this->setParams($params);
         $this->setEnabled(true);
 
-        // Set empty config param if not exists
         if (!$this->hasParam('config')) {
             $this->setParam('config', []);
         }
@@ -258,6 +263,47 @@ class Connection extends Param
     }
 
     /**
+     * Get or create elasticsearch-php v9 Client instance.
+     *
+     * V9: This method provides access to the native elasticsearch-php v9 client.
+     * Used for direct API method calls like $client->indices()->refresh().
+     */
+    public function getClient(): ElasticsearchClient
+    {
+        if (null !== $this->_client) {
+            return $this->_client;
+        }
+
+        $hosts = [];
+        $scheme = $this->hasParam('ssl') && $this->getParam('ssl') ? 'https' : 'http';
+        $host = $this->getHost();
+        $port = $this->getPort();
+        $path = $this->getPath();
+
+        $hostString = \sprintf('%s://%s:%d%s', $scheme, $host, $port, $path);
+        $hosts[] = $hostString;
+
+        $builder = ClientBuilder::create()
+            ->setHosts($hosts)
+        ;
+
+        if ($this->hasParam('username') && $this->hasParam('password')) {
+            $builder->setBasicAuthentication(
+                $this->getParam('username'),
+                $this->getParam('password')
+            );
+        }
+
+        if ($this->hasParam('api_key')) {
+            $builder->setApiKey($this->getParam('api_key'));
+        }
+
+        $this->_client = $builder->build();
+
+        return $this->_client;
+    }
+
+    /**
      * @return bool Returns true if connection is persistent. True by default
      */
     public function isPersistent()
@@ -275,7 +321,6 @@ class Connection extends Param
 
     /**
      * @param string $key
-     * @param mixed  $value
      *
      * @return $this
      */
@@ -325,7 +370,7 @@ class Connection extends Param
     /**
      * @param array|Connection $params Params to create a connection
      *
-     * @throws Exception\InvalidException
+     * @throws InvalidException
      *
      * @return self
      */

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -10,6 +10,7 @@ use Elastica\Request;
 use Elastica\Test\Base as BaseTest;
 use Elastica\Transport\AbstractTransport;
 use Elastica\Transport\Http;
+use Psr\Log\NullLogger;
 
 /**
  * @internal
@@ -25,7 +26,7 @@ class ConnectionTest extends BaseTest
         $this->assertEquals(Connection::DEFAULT_HOST, $connection->getHost());
         $this->assertEquals(Connection::DEFAULT_PORT, $connection->getPort());
         $this->assertEquals(Connection::DEFAULT_TRANSPORT, $connection->getTransport());
-        $this->assertInstanceOf(AbstractTransport::class, $connection->getTransportObject());
+        $this->assertInstanceOf(AbstractTransport::class, $connection->getTransportObject(new NullLogger(), false));
         $this->assertEquals(Connection::TIMEOUT, $connection->getTimeout());
         $this->assertEquals(Connection::CONNECT_TIMEOUT, $connection->getConnectTimeout());
         $this->assertEquals([], $connection->getConfig());
@@ -57,7 +58,6 @@ class ConnectionTest extends BaseTest
         $request = new Request('_stats', Request::GET);
         $request->setConnection($connection);
 
-        // Throws exception because no valid connection
         $request->send();
     }
 
@@ -105,7 +105,7 @@ class ConnectionTest extends BaseTest
     public function testGetConfigWithArrayUsedForTransport(): void
     {
         $connection = new Connection(['transport' => ['type' => 'Http']]);
-        $this->assertInstanceOf(Http::class, $connection->getTransportObject());
+        $this->assertInstanceOf(Http::class, $connection->getTransportObject(new NullLogger(), false));
     }
 
     /**
@@ -117,7 +117,8 @@ class ConnectionTest extends BaseTest
         $this->expectExceptionMessage('Invalid transport');
 
         $connection = new Connection(['transport' => ['type' => 'invalidtransport']]);
-        $connection->getTransportObject();
+        $logger = new NullLogger();
+        $connection->getTransportObject($logger, false);
     }
 
     /**


### PR DESCRIPTION
Description: Migrate Connection class to use the ES v9 native client factory
Possible impact: Connection, client instantiation, transport layer

---
## Summary
- Adds ES v9 native client factory method to `src/Connection.php`
- Wires up the new elasticsearch-php v9 client builder within the Connection class

## Stacked PRs (2/9)
> `opensearch` → `infra-deps` → **This PR** → `index-api` → `client-bulk` → `secondary-src` → `tests-bulk` → `tests-multi-aggregation` → `tests-transport` → `tests-remaining`

⚠️ **Base branch is `DE-159650-upgrade-elasticsearch-infra-deps` — merge that first.**

## Test Plan
- [ ] Unit tests for Connection pass
- [ ] Client can be instantiated using new factory

🤖 Generated with [Claude Code](https://claude.com/claude-code)