### PR TITLE
DE-160171 Add PHP 8.4 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "homepage": "http://elastica.io/",
     "require": {
-        "php": "^7.2 || ^8.0",
+        "php": "~8.2 || ~8.4",
         "ext-json": "*",
         "elasticsearch/elasticsearch": "^7.1.1",
         "nyholm/dsn": "^2.0.0",

--- a/src/Client.php
+++ b/src/Client.php
@@ -97,8 +97,8 @@ class Client
     public function __construct(
         array $config = [],
         $callback = null,
-        LoggerInterface $logger = null,
-        RequestCounterInterface $requestCounter = null,
+        ?LoggerInterface $logger = null,
+        ?RequestCounterInterface $requestCounter = null,
         bool $isRetryFeatureEnabled = false,
         int $slowRequestThresholdMs = self::DEFAULT_SLOW_REQUEST_THRESHOLD_IN_MS
     ) {


### PR DESCRIPTION
Description: Add PHP 8.4 compatibility with backwards-compatible changes
Possible impact: PHP version constraint, deprecated function fixes

---
## Summary
- Fix implicit nullable parameters in `Client` constructor (BC-001: `LoggerInterface` and `RequestCounterInterface`)
- Update PHP version constraint from `^7.2 || ^8.0` to `~8.2 || ~8.4`
- All changes backwards-compatible with PHP 8.2

## Breaking Changes Addressed
- **BC-001**: Implicit nullable parameters deprecated in PHP 8.4 - Added explicit `?` nullable type to `LoggerInterface $logger` and `RequestCounterInterface $requestCounter` in `Client::__construct()`

## Test Plan
- [ ] CI passes on PHP 8.2
- [ ] Manual verification of fixes against PHP 8.4 migration guide

🤖 Generated with [Claude Code](https://claude.com/claude-code)