### PR TITLE
security: redact username and password in Request::toArray()

### DIFF
--- a/lib/Elastica/Request.php
+++ b/lib/Elastica/Request.php
@@ -200,7 +200,13 @@ class Request extends Param
     {
         $data = $this->getParams();
         if ($this->_connection) {
-            $data['connection'] = $this->_connection->getParams();
+            $connectionParams = $this->_connection->getParams();
+            foreach (['username', 'password'] as $sensitiveKey) {
+                if (isset($connectionParams[$sensitiveKey])) {
+                    $connectionParams[$sensitiveKey] = '***';
+                }
+            }
+            $data['connection'] = $connectionParams;
         }
 
         return $data;


### PR DESCRIPTION
Description: Redact username and password with `***` in `Request::toArray()` to prevent credentials from appearing in logs
Possible impact: Logging output, any code that relies on `toArray()` or `toString()` returning real credentials

---
## Problem

`Request::toArray()` includes the full connection params, including `username` and `password` in plaintext. This method is called in two places inside `Client::_log()`:

1. **`ConnectionException` path** — logged as `error`: `$context->getRequest()->toArray()`
2. **Normal request path** — logged as `debug`: `$context->toArray()`

Additionally, platform-backend's custom slow query logger also calls `toArray()` when logging slow ES requests. This causes ES credentials to appear in application logs (e.g. Kibana) for every slow query.

## Decision: always redact, no opt-out parameter

We considered adding a `$hideSensitiveData = true` parameter to allow the `ConnectionException` path to log credentials (potentially useful for debugging which connection failed). This was rejected because:

- Anyone who can read `error` logs in production has the same access as anyone reading slow query logs — the security boundary is the same
- `password` should never appear in logs regardless of context
- Keeping `username` visible in `ConnectionException` logs (while redacting `password`) would add complexity for minimal gain
- A simpler, consistent rule is easier to reason about

## Change

In `Request::toArray()`, replace `username` and `password` in the connection params with `***`:

```php
$connectionParams = $this->_connection->getParams();
foreach (['username', 'password'] as $sensitiveKey) {
    if (isset($connectionParams[$sensitiveKey])) {
        $connectionParams[$sensitiveKey] = '***';
    }
}
$data['connection'] = $connectionParams;
```

## Notes

- No functional change — only affects the serialized representation used in logging/debugging
- If a caller genuinely needs real credentials from a `Request` object, they should call `getConnection()->getParams()` directly
- Submitting as draft for architecture review

🤖 Generated with [Claude Code](https://claude.com/claude-code)