### PR TITLE
fix: mask sensitive connection credentials in toArray()

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -150,7 +150,7 @@ class Request extends Param
     /**
      * Return Connection Object.
      *
-     * @throws Exception\InvalidException If no valid connection was set
+     * @throws InvalidException If no valid connection was set
      */
     public function getConnection(): Connection
     {
@@ -205,7 +205,13 @@ class Request extends Param
     {
         $data = $this->getParams();
         if ($this->_connection) {
-            $data['connection'] = $this->_connection->getParams();
+            $connectionParams = $this->_connection->getParams();
+            foreach (['username', 'password'] as $sensitiveKey) {
+                if (isset($connectionParams[$sensitiveKey])) {
+                    $connectionParams[$sensitiveKey] = '***';
+                }
+            }
+            $data['connection'] = $connectionParams;
         }
 
         return $data;

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -99,6 +99,20 @@ class RequestTest extends BaseTest
 
     /**
      * @group unit
+     */
+    public function testToArrayMasksSensitiveConnectionCredentials(): void
+    {
+        $connection = new Connection(['host' => 'localhost', 'port' => 9200, 'username' => 'elastic', 'password' => 'secret']);
+
+        $request = new Request('_search', Request::GET, [], [], $connection);
+        $data = $request->toArray();
+
+        $this->assertSame('***', $data['connection']['username']);
+        $this->assertSame('***', $data['connection']['password']);
+    }
+
+    /**
+     * @group unit
      * @group legacy
      */
     public function testLegacyToString(): void

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -70,9 +70,12 @@ class RequestTest extends BaseTest
         $query = ['no' => 'params'];
         $data = ['key' => 'value'];
 
-        $connection = new Connection();
-        $connection->setHost($this->_getHost());
-        $connection->setPort(9200);
+        $connection = new Connection([
+            'host' => $this->_getHost(),
+            'port' => 9200,
+            'username' => 'elastic',
+            'password' => 'secret',
+        ]);
 
         $request = new Request($path, $method, $data, $query, $connection);
 
@@ -94,21 +97,9 @@ class RequestTest extends BaseTest
         $this->assertEquals($request->getConnection()->getHost(), $data['connection']['host']);
         $this->assertEquals($request->getConnection()->getPort(), $data['connection']['port']);
 
-        $this->assertIsString((string) $request);
-    }
-
-    /**
-     * @group unit
-     */
-    public function testToArrayMasksSensitiveConnectionCredentials(): void
-    {
-        $connection = new Connection(['host' => 'localhost', 'port' => 9200, 'username' => 'elastic', 'password' => 'secret']);
-
-        $request = new Request('_search', Request::GET, [], [], $connection);
-        $data = $request->toArray();
-
         $this->assertSame('***', $data['connection']['username']);
         $this->assertSame('***', $data['connection']['password']);
+        $this->assertIsString((string) $request);
     }
 
     /**


### PR DESCRIPTION
Description: Mask username and password in connection params when serializing request to array
Possible impact: Logging, debugging output, request serialization

---
Port of #37 to the `opensearch` branch.

## Summary
- Masks `username` and `password` fields in `$_connection->getParams()` with `***` in `Request::toArray()`
- Prevents credentials from leaking into logs or debug output

🤖 Generated with [Claude Code](https://claude.com/claude-code)